### PR TITLE
32bit vs. 16bit floating point numbers

### DIFF
--- a/camera.h
+++ b/camera.h
@@ -12,27 +12,31 @@
 __device__ vec3 random_in_unit_disk(curandState *local_rand_state) {
     vec3 p;
     do {
-        p = 2.0f*vec3(curand_uniform(local_rand_state),curand_uniform(local_rand_state),0) - vec3(1,1,0);
-    } while (dot(p,p) >= 1.0f);
+        p = real_t(2.0f)*vec3(curand_uniform(local_rand_state),curand_uniform(local_rand_state),0) - vec3(1,1,0);
+    } while (dot(p,p) >= real_t(1.0f));
     return p;
 }
 
 class camera {
 public:
     __device__ camera(vec3 lookfrom, vec3 lookat, vec3 vup, real_t vfov, real_t aspect, real_t aperture, real_t focus_dist) { // vfov is top to bottom in degrees
-        lens_radius = aperture / 2.0f;
-        real_t theta = vfov*((real_t)M_PI)/180.0f;
+        lens_radius = aperture / real_t(2.0f);
+        real_t theta = vfov*((real_t)M_PI)/real_t(180.0f);
         // real_t half_height = tan(theta/2.0f);
         real_t arg = theta/real_t(2.0f);
-        real_t half_height = hsin(arg) / hcos(arg); // no tan function in nvidia fp16 math
+#ifdef __CUDA_ARCH__
+        real_t half_height = hsin(arg.val) / hcos(arg.val); // no tan function in nvidia fp16 math
+#else
+        real_t half_height = tan(arg);
+#endif
         real_t half_width = aspect * half_height;
         origin = lookfrom;
         w = unit_vector(lookfrom - lookat);
         u = unit_vector(cross(vup, w));
         v = cross(w, u);
         lower_left_corner = origin  - half_width*focus_dist*u -half_height*focus_dist*v - focus_dist*w;
-        horizontal = 2.0f*half_width*focus_dist*u;
-        vertical = 2.0f*half_height*focus_dist*v;
+        horizontal = real_t(2.0f)*half_width*focus_dist*u;
+        vertical = real_t(2.0f)*half_height*focus_dist*v;
     }
     __device__ ray get_ray(real_t s, real_t t, curandState *local_rand_state) {
         vec3 rd = lens_radius*random_in_unit_disk(local_rand_state);

--- a/camera.h
+++ b/camera.h
@@ -25,9 +25,13 @@ public:
         // real_t half_height = tan(theta/2.0f);
         real_t arg = theta/real_t(2.0f);
 #ifdef __CUDA_ARCH__
-        real_t half_height = hsin(arg.val) / hcos(arg.val); // no tan function in nvidia fp16 math
-#else
+    #ifdef USE_FP16
+        real_t half_height = real_t(hsin(arg.val) / hcos(arg.val));
+    #else
         real_t half_height = tan(arg);
+    #endif
+#else
+    real_t half_height = tan(arg);
 #endif
         real_t half_width = aspect * half_height;
         origin = lookfrom;

--- a/camera.h
+++ b/camera.h
@@ -3,6 +3,7 @@
 
 #include <curand_kernel.h>
 #include "ray.h"
+#include "precision_types.h"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -18,11 +19,13 @@ __device__ vec3 random_in_unit_disk(curandState *local_rand_state) {
 
 class camera {
 public:
-    __device__ camera(vec3 lookfrom, vec3 lookat, vec3 vup, float vfov, float aspect, float aperture, float focus_dist) { // vfov is top to bottom in degrees
+    __device__ camera(vec3 lookfrom, vec3 lookat, vec3 vup, real_t vfov, real_t aspect, real_t aperture, real_t focus_dist) { // vfov is top to bottom in degrees
         lens_radius = aperture / 2.0f;
-        float theta = vfov*((float)M_PI)/180.0f;
-        float half_height = tan(theta/2.0f);
-        float half_width = aspect * half_height;
+        real_t theta = vfov*((real_t)M_PI)/180.0f;
+        // real_t half_height = tan(theta/2.0f);
+        real_t arg = theta/real_t(2.0f);
+        real_t half_height = hsin(arg) / hcos(arg); // no tan function in nvidia fp16 math
+        real_t half_width = aspect * half_height;
         origin = lookfrom;
         w = unit_vector(lookfrom - lookat);
         u = unit_vector(cross(vup, w));
@@ -31,7 +34,7 @@ public:
         horizontal = 2.0f*half_width*focus_dist*u;
         vertical = 2.0f*half_height*focus_dist*v;
     }
-    __device__ ray get_ray(float s, float t, curandState *local_rand_state) {
+    __device__ ray get_ray(real_t s, real_t t, curandState *local_rand_state) {
         vec3 rd = lens_radius*random_in_unit_disk(local_rand_state);
         vec3 offset = u * rd.x() + v * rd.y();
         return ray(origin + offset, lower_left_corner + s*horizontal + t*vertical - origin - offset);
@@ -42,7 +45,7 @@ public:
     vec3 horizontal;
     vec3 vertical;
     vec3 u, v, w;
-    float lens_radius;
+    real_t lens_radius;
 };
 
 #endif

--- a/hitable.h
+++ b/hitable.h
@@ -2,12 +2,13 @@
 #define HITABLEH
 
 #include "ray.h"
+#include "precision_types.h"
 
 class material;
 
 struct hit_record
 {
-    float t;
+    real_t t;
     vec3 p;
     vec3 normal;
     material *mat_ptr;
@@ -15,7 +16,7 @@ struct hit_record
 
 class hitable  {
     public:
-        __device__ virtual bool hit(const ray& r, float t_min, float t_max, hit_record& rec) const = 0;
+        __device__ virtual bool hit(const ray& r, real_t t_min, real_t t_max, hit_record& rec) const = 0;
 };
 
 #endif

--- a/hitable_list.h
+++ b/hitable_list.h
@@ -2,20 +2,21 @@
 #define HITABLELISTH
 
 #include "hitable.h"
+#include "precision_types.h"
 
 class hitable_list: public hitable  {
     public:
         __device__ hitable_list() {}
         __device__ hitable_list(hitable **l, int n) {list = l; list_size = n; }
-        __device__ virtual bool hit(const ray& r, float tmin, float tmax, hit_record& rec) const;
+        __device__ virtual bool hit(const ray& r, real_t tmin, real_t tmax, hit_record& rec) const;
         hitable **list;
         int list_size;
 };
 
-__device__ bool hitable_list::hit(const ray& r, float t_min, float t_max, hit_record& rec) const {
+__device__ bool hitable_list::hit(const ray& r, real_t t_min, real_t t_max, hit_record& rec) const {
         hit_record temp_rec;
         bool hit_anything = false;
-        float closest_so_far = t_max;
+        real_t closest_so_far = t_max;
         for (int i = 0; i < list_size; i++) {
             if (list[i]->hit(r, t_min, closest_so_far, temp_rec)) {
                 hit_anything = true;

--- a/main.cu
+++ b/main.cu
@@ -137,11 +137,11 @@ __global__ void create_world(hitable** d_list, hitable** d_world, camera** d_cam
 			for (int b = -11; b < 11; b++) {
 				const real_t choose_mat = RND;
 				const vec3 center(a + RND, 0.2, b + RND);
-				if (choose_mat < 0.8f) {
+				if (choose_mat < real_t(0.8f)) {
 					d_list[i++] = new sphere(center, 0.2,
 						new lambertian(vec3(RND * RND, RND * RND, RND * RND)));
 				}
-				else if (choose_mat < 0.95f) {
+				else if (choose_mat < real_t(0.95f)) {
 					d_list[i++] = new sphere(center, 0.2,
 						new metal(vec3(0.5f * (1.0f + RND), 0.5f * (1.0f + RND), 0.5f * (1.0f + RND)), 0.5f * RND));
 				}

--- a/main.cu
+++ b/main.cu
@@ -158,8 +158,8 @@ __global__ void create_world(hitable** d_list, hitable** d_world, camera** d_cam
 
 		const vec3 lookfrom(13, 2, 3);
 		const vec3 lookat(0, 0, 0);
-		constexpr real_t dist_to_focus = 10.0; (lookfrom - lookat).length();
-		constexpr real_t aperture = 0.1;
+		const real_t dist_to_focus = 10.0; (lookfrom - lookat).length();
+		const real_t aperture = 0.1;
 		*d_camera = new camera(lookfrom,
 			lookat,
 			vec3(0, 1, 0),
@@ -306,11 +306,11 @@ void output_to_file(const int nx, const int ny, const vec3* fb)
 }
 
 int main(int argc, char** argv) {
-	constexpr int nx = 1200;
-	constexpr int ny = 800;
-	constexpr int ns = 10;
-	constexpr int tx = 8;
-	constexpr int ty = 8;
+	const int nx = 1200;
+	const int ny = 800;
+	const int ns = 10;
+	const int tx = 8;
+	const int ty = 8;
 
 	std::cerr << "Rendering a " << nx << "x" << ny << " image with " << ns << " samples per pixel ";
 	std::cerr << "in " << tx << "x" << ty << " blocks.\n";
@@ -321,8 +321,8 @@ int main(int argc, char** argv) {
 	}
 	std::cerr << "Output mode: " << output_mode << "\n";
 
-	constexpr int num_pixels = nx * ny;
-	constexpr size_t fb_size = num_pixels * sizeof(vec3);
+	const int num_pixels = nx * ny;
+	const size_t fb_size = num_pixels * sizeof(vec3);
 
 	// allocate FB
 	vec3* fb;
@@ -341,7 +341,7 @@ int main(int argc, char** argv) {
 
 	// make our world of hitables & the camera
 	hitable** d_list;
-	constexpr int num_hitables = 22 * 22 + 1 + 3;
+	const int num_hitables = 22 * 22 + 1 + 3;
 	checkCudaErrors(cudaMalloc(reinterpret_cast<void**>(&d_list), num_hitables * sizeof(hitable*)));
 	hitable** d_world;
 	checkCudaErrors(cudaMalloc(reinterpret_cast<void**>(&d_world), sizeof(hitable*)));

--- a/material.h
+++ b/material.h
@@ -5,20 +5,21 @@ struct hit_record;
 
 #include "ray.h"
 #include "hitable.h"
+#include "precision_types.h"
 
 
-__device__ float schlick(float cosine, float ref_idx) {
-    float r0 = (1.0f-ref_idx) / (1.0f+ref_idx);
+__device__ real_t schlick(real_t cosine, real_t ref_idx) {
+    real_t r0 = real_t(1.0f-ref_idx) / real_t(1.0f+ref_idx);
     r0 = r0*r0;
-    return r0 + (1.0f-r0)*pow((1.0f - cosine),5.0f);
+    return real_t(r0 + (1.0f-r0)*pow((1.0f - cosine),5.0f)); // TODO: pow computed in 32bit for now
 }
 
-__device__ bool refract(const vec3& v, const vec3& n, float ni_over_nt, vec3& refracted) {
+__device__ bool refract(const vec3& v, const vec3& n, real_t ni_over_nt, vec3& refracted) {
     vec3 uv = unit_vector(v);
-    float dt = dot(uv, n);
-    float discriminant = 1.0f - ni_over_nt*ni_over_nt*(1-dt*dt);
+    real_t dt = dot(uv, n);
+    real_t discriminant = real_t(1.0f) - ni_over_nt*ni_over_nt*((real_t)1.0f-dt*dt);
     if (discriminant > 0) {
-        refracted = ni_over_nt*(uv - n*dt) - n*sqrt(discriminant);
+        refracted = ni_over_nt*(uv - n*dt) - n*real_t::sqrt(discriminant);
         return true;
     }
     else
@@ -59,7 +60,7 @@ class lambertian : public material {
 
 class metal : public material {
     public:
-        __device__ metal(const vec3& a, float f) : albedo(a) { if (f < 1) fuzz = f; else fuzz = 1; }
+        __device__ metal(const vec3& a, real_t f) : albedo(a) { if (f < 1) fuzz = f; else fuzz = 1; }
         __device__ virtual bool scatter(const ray& r_in, const hit_record& rec, vec3& attenuation, ray& scattered, curandState *local_rand_state) const  {
             vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
             scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(local_rand_state));
@@ -67,12 +68,12 @@ class metal : public material {
             return (dot(scattered.direction(), rec.normal) > 0.0f);
         }
         vec3 albedo;
-        float fuzz;
+        real_t fuzz;
 };
 
 class dielectric : public material {
 public:
-    __device__ dielectric(float ri) : ref_idx(ri) {}
+    __device__ dielectric(real_t ri) : ref_idx(ri) {}
     __device__ virtual bool scatter(const ray& r_in,
                          const hit_record& rec,
                          vec3& attenuation,
@@ -80,11 +81,11 @@ public:
                          curandState *local_rand_state) const  {
         vec3 outward_normal;
         vec3 reflected = reflect(r_in.direction(), rec.normal);
-        float ni_over_nt;
+        real_t ni_over_nt;
         attenuation = vec3(1.0, 1.0, 1.0);
         vec3 refracted;
-        float reflect_prob;
-        float cosine;
+        real_t reflect_prob;
+        real_t cosine;
         if (dot(r_in.direction(), rec.normal) > 0.0f) {
             outward_normal = -rec.normal;
             ni_over_nt = ref_idx;
@@ -107,6 +108,6 @@ public:
         return true;
     }
 
-    float ref_idx;
+    real_t ref_idx;
 };
 #endif

--- a/material.h
+++ b/material.h
@@ -11,7 +11,7 @@ struct hit_record;
 __device__ real_t schlick(real_t cosine, real_t ref_idx) {
     real_t r0 = real_t(1.0f-ref_idx) / real_t(1.0f+ref_idx);
     r0 = r0*r0;
-    return real_t(r0 + real_t(1.0f-r0)*pow((1.0f - cosine),5.0f)); // TODO: pow computed in 32bit for now
+    return real_t(r0 + real_t(1.0f-r0)*real_t(pow((1.0f - cosine),5.0f))); // TODO: pow computed in 32bit for now
 }
 
 __device__ bool refract(const vec3& v, const vec3& n, real_t ni_over_nt, vec3& refracted) {
@@ -19,7 +19,11 @@ __device__ bool refract(const vec3& v, const vec3& n, real_t ni_over_nt, vec3& r
     real_t dt = dot(uv, n);
     real_t discriminant = real_t(1.0f) - ni_over_nt*ni_over_nt*((real_t)1.0f-dt*dt);
     if (discriminant > real_t(0)) {
+#ifdef USE_FP16
         refracted = ni_over_nt*(uv - n*dt) - n*real_t::sqrt(discriminant);
+#else
+        refracted = ni_over_nt*(uv - n*dt) - n*sqrt(discriminant);
+#endif
         return true;
     }
     else

--- a/precision_types.h
+++ b/precision_types.h
@@ -5,7 +5,7 @@
 #include <fstream>
 
 // comment for float32
-#define USE_FP16
+// #define USE_FP16
 
 // by cuda:
 // https://docs.nvidia.com/cuda/archive/11.7.1/cuda-math-api/group__CUDA__MATH____HALF__FUNCTIONS.html#group__CUDA__MATH____HALF__FUNCTIONS

--- a/precision_types.h
+++ b/precision_types.h
@@ -6,171 +6,162 @@
 // comment for float32
 #define USE_FP16
 
-
 // by cuda:
 // https://docs.nvidia.com/cuda/archive/11.7.1/cuda-math-api/group__CUDA__MATH____HALF__FUNCTIONS.html#group__CUDA__MATH____HALF__FUNCTIONS
-// hsqrt(x), hrsqrt(x), 
+// hsqrt(x), hrsqrt(x),
 
 #ifdef USE_FP16
-    struct real_t {
-        __half val;
+struct real_t
+{
+    __half val;
 
-        // Constructors
-        __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
-        __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
-        __host__ __device__ __forceinline__ real_t(const __half& h) : val(h) {}
-        
-        // Conversion
-        __host__ __device__ __forceinline__ operator float() const { return __half2float(val); }
-        
-        // Basic arithmetic operators
-        __device__ __forceinline__ real_t operator+(const real_t& other) const { 
-            return real_t(__hadd(val, other.val)); 
-        }
-        
-        __device__ __forceinline__ real_t operator-(const real_t& other) const { 
-            return real_t(__hsub(val, other.val)); 
-        }
-        
-        __device__ __forceinline__ real_t operator*(const real_t& other) const { 
-            return real_t(__hmul(val, other.val)); 
-        }
-        
-        __device__ __forceinline__ real_t operator/(const real_t& other) const { 
-            return real_t(__hdiv(val, other.val)); 
-        }
-        
-        // Compound assignment operators
-        __device__ __forceinline__ real_t& operator+=(const real_t& other) { 
-            val = __hadd(val, other.val); 
-            return *this; 
-        }
-        
-        __device__ __forceinline__ real_t& operator-=(const real_t& other) { 
-            val = __hsub(val, other.val); 
-            return *this; 
-        }
-        
-        __device__ __forceinline__ real_t& operator*=(const real_t& other) { 
-            val = __hmul(val, other.val); 
-            return *this; 
-        }
-        
-        __device__ __forceinline__ real_t& operator/=(const real_t& other) { 
-            val = __hdiv(val, other.val); 
-            return *this; 
-        }
-        
-        // Comparison operators
-        __device__ __forceinline__ bool operator<(const real_t& other) const { 
-            return __hlt(val, other.val); 
-        }
-        
-        __device__ __forceinline__ bool operator>(const real_t& other) const { 
-            return __hgt(val, other.val); 
-        }
-        
-        __device__ __forceinline__ bool operator<=(const real_t& other) const { 
-            return __hle(val, other.val); 
-        }
-        
-        __device__ __forceinline__ bool operator>=(const real_t& other) const { 
-            return __hge(val, other.val); 
-        }
-        
-        // math
-        __device__ __forceinline__ static real_t sqrt(const real_t& x) { 
-            return real_t(hsqrt(x.val)); 
-        }
+    // Constructors
+    __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
+    __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
+    __host__ __device__ __forceinline__ real_t(const __half &h) : val(h) {}
 
-        __device__ __forceinline__ static real_t rsqrt(const real_t& x) { 
-            return real_t(hrsqrt(x.val)); // 1/sqrt(x)
-        }
-        
-    };
+    // Conversion
+    __host__ __device__ __forceinline__ operator float() const { return __half2float(val); }
 
-    // Non-member atomic operation
-    __device__ __forceinline__ void atomic_add(real_t* address, real_t val) {
-        atomicAdd(&(address->val), val.val);
-    }
-
+    // Basic arithmetic operators
+    __host__ __device__ __forceinline__ real_t operator+(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return real_t(__hadd(val, other.val));
 #else
-    struct real_t {
-        float val;
-
-        // Constructors
-        __host__ __device__ __forceinline__ real_t() : val(0.0f) {}
-        __host__ __device__ __forceinline__ real_t(float f) : val(f) {}
-        
-        // Conversion
-        __host__ __device__ __forceinline__ operator float() const { return val; }
-        
-        // Basic arithmetic operators
-        __device__ __forceinline__ real_t operator+(const real_t& other) const { 
-            return real_t(val + other.val); 
-        }
-        
-        __device__ __forceinline__ real_t operator-(const real_t& other) const { 
-            return real_t(val - other.val); 
-        }
-        
-        __device__ __forceinline__ real_t operator*(const real_t& other) const { 
-            return real_t(val * other.val); 
-        }
-        
-        __device__ __forceinline__ real_t operator/(const real_t& other) const { 
-            return real_t(val / other.val); 
-        }
-        
-        // Compound assignment operators
-        __device__ __forceinline__ real_t& operator+=(const real_t& other) { 
-            val += other.val; 
-            return *this; 
-        }
-        
-        __device__ __forceinline__ real_t& operator-=(const real_t& other) { 
-            val -= other.val; 
-            return *this; 
-        }
-        
-        __device__ __forceinline__ real_t& operator*=(const real_t& other) { 
-            val *= other.val; 
-            return *this; 
-        }
-        
-        __device__ __forceinline__ real_t& operator/=(const real_t& other) { 
-            val /= other.val; 
-            return *this; 
-        }
-        
-        // Comparison operators
-        __device__ __forceinline__ bool operator<(const real_t& other) const { 
-            return val < other.val; 
-        }
-        
-        __device__ __forceinline__ bool operator>(const real_t& other) const { 
-            return val > other.val; 
-        }
-        
-        __device__ __forceinline__ bool operator<=(const real_t& other) const { 
-            return val <= other.val; 
-        }
-        
-        __device__ __forceinline__ bool operator>=(const real_t& other) const { 
-            return val >= other.val; 
-        }
-        
-        // math
-        __device__ __forceinline__ static real_t sqrt(const real_t& x) { 
-            return real_t(sqrtf(x.val)); 
-        }
-        
-    };
-
-    // Non-member atomic operation
-    __device__ __forceinline__ void atomic_add(real_t* address, real_t val) {
-        atomicAdd(&(address->val), val.val);
+        return real_t(__half2float(val) + __half2float(other.val));
+#endif
     }
+
+    __host__ __device__ __forceinline__ real_t operator-(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return real_t(__hsub(val, other.val));
+#else
+        return real_t(__half2float(val) - __half2float(other.val));
+#endif
+    }
+
+    __host__ __device__ __forceinline__ real_t operator*(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return real_t(__hmul(val, other.val));
+#else
+        return real_t(__half2float(val) * __half2float(other.val));
+#endif
+    }
+
+    __host__ __device__ __forceinline__ real_t operator/(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return real_t(__hdiv(val, other.val));
+#else
+        return real_t(__half2float(val) / __half2float(other.val));
+#endif
+    }
+
+    // Compound assignment operators
+    __host__ __device__ __forceinline__ real_t &operator+=(const real_t &other)
+    {
+#ifdef __CUDA_ARCH__
+        val = __hadd(val, other.val);
+#else
+        val = __float2half(__half2float(val) + __half2float(other.val));
+#endif
+        return *this;
+    }
+
+    __host__ __device__ __forceinline__ real_t &operator-=(const real_t &other)
+    {
+#ifdef __CUDA_ARCH__
+        val = __hsub(val, other.val);
+#else
+        val = __float2half(__half2float(val) - __half2float(other.val));
+#endif
+        return *this;
+    }
+
+    __host__ __device__ __forceinline__ real_t &operator*=(const real_t &other)
+    {
+#ifdef __CUDA_ARCH__
+        val = __hmul(val, other.val);
+#else
+        val = __float2half(__half2float(val) * __half2float(other.val));
+#endif
+        return *this;
+    }
+
+    __host__ __device__ __forceinline__ real_t &operator/=(const real_t &other)
+    {
+#ifdef __CUDA_ARCH__
+        val = __hdiv(val, other.val);
+#else
+        val = __float2half(__half2float(val) / __half2float(other.val));
+#endif
+        return *this;
+    }
+
+    // Comparison operators
+    __host__ __device__ __forceinline__ bool operator<(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return __hlt(val, other.val);
+#else
+        return __half2float(val) < __half2float(other.val);
+#endif
+    }
+
+    __host__ __device__ __forceinline__ bool operator>(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return __hgt(val, other.val);
+#else
+        return __half2float(val) > __half2float(other.val);
+#endif
+    }
+
+    __host__ __device__ __forceinline__ bool operator<=(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return __hle(val, other.val);
+#else
+        return __half2float(val) <= __half2float(other.val);
+#endif
+    }
+
+    __host__ __device__ __forceinline__ bool operator>=(const real_t &other) const
+    {
+#ifdef __CUDA_ARCH__
+        return __hge(val, other.val);
+#else
+        return __half2float(val) >= __half2float(other.val);
+#endif
+    }
+
+    // math
+    __host__ __device__ __forceinline__ static real_t sqrt(const real_t &x)
+    {
+#ifdef __CUDA_ARCH__
+        return real_t(hsqrt(x.val));
+#else
+        return real_t(sqrtf(__half2float(x.val)));
+#endif
+    }
+
+    __host__ __device__ __forceinline__ static real_t rsqrt(const real_t &x)
+    {
+#ifdef __CUDA_ARCH__
+        return real_t(hrsqrt(x.val));
+#else
+        return real_t(1.0f / sqrtf(__half2float(x.val)));
+#endif
+    }
+};
+
+
+// FP32
+#else
+typedef float real_t;
 
 #endif
 

--- a/precision_types.h
+++ b/precision_types.h
@@ -1,0 +1,177 @@
+#ifndef PRECISION_TYPES_H
+#define PRECISION_TYPES_H
+
+#include <cuda_fp16.h>
+
+// comment for float32
+#define USE_FP16
+
+
+// by cuda:
+// https://docs.nvidia.com/cuda/archive/11.7.1/cuda-math-api/group__CUDA__MATH____HALF__FUNCTIONS.html#group__CUDA__MATH____HALF__FUNCTIONS
+// hsqrt(x), hrsqrt(x), 
+
+#ifdef USE_FP16
+    struct real_t {
+        __half val;
+
+        // Constructors
+        __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
+        __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
+        __host__ __device__ __forceinline__ real_t(const __half& h) : val(h) {}
+        
+        // Conversion
+        __host__ __device__ __forceinline__ operator float() const { return __half2float(val); }
+        
+        // Basic arithmetic operators
+        __device__ __forceinline__ real_t operator+(const real_t& other) const { 
+            return real_t(__hadd(val, other.val)); 
+        }
+        
+        __device__ __forceinline__ real_t operator-(const real_t& other) const { 
+            return real_t(__hsub(val, other.val)); 
+        }
+        
+        __device__ __forceinline__ real_t operator*(const real_t& other) const { 
+            return real_t(__hmul(val, other.val)); 
+        }
+        
+        __device__ __forceinline__ real_t operator/(const real_t& other) const { 
+            return real_t(__hdiv(val, other.val)); 
+        }
+        
+        // Compound assignment operators
+        __device__ __forceinline__ real_t& operator+=(const real_t& other) { 
+            val = __hadd(val, other.val); 
+            return *this; 
+        }
+        
+        __device__ __forceinline__ real_t& operator-=(const real_t& other) { 
+            val = __hsub(val, other.val); 
+            return *this; 
+        }
+        
+        __device__ __forceinline__ real_t& operator*=(const real_t& other) { 
+            val = __hmul(val, other.val); 
+            return *this; 
+        }
+        
+        __device__ __forceinline__ real_t& operator/=(const real_t& other) { 
+            val = __hdiv(val, other.val); 
+            return *this; 
+        }
+        
+        // Comparison operators
+        __device__ __forceinline__ bool operator<(const real_t& other) const { 
+            return __hlt(val, other.val); 
+        }
+        
+        __device__ __forceinline__ bool operator>(const real_t& other) const { 
+            return __hgt(val, other.val); 
+        }
+        
+        __device__ __forceinline__ bool operator<=(const real_t& other) const { 
+            return __hle(val, other.val); 
+        }
+        
+        __device__ __forceinline__ bool operator>=(const real_t& other) const { 
+            return __hge(val, other.val); 
+        }
+        
+        // math
+        __device__ __forceinline__ static real_t sqrt(const real_t& x) { 
+            return real_t(hsqrt(x.val)); 
+        }
+        
+    };
+
+    // Non-member atomic operation
+    __device__ __forceinline__ void atomic_add(real_t* address, real_t val) {
+        atomicAdd(&(address->val), val.val);
+    }
+
+#else
+    struct real_t {
+        float val;
+
+        // Constructors
+        __host__ __device__ __forceinline__ real_t() : val(0.0f) {}
+        __host__ __device__ __forceinline__ real_t(float f) : val(f) {}
+        
+        // Conversion
+        __host__ __device__ __forceinline__ operator float() const { return val; }
+        
+        // Basic arithmetic operators
+        __device__ __forceinline__ real_t operator+(const real_t& other) const { 
+            return real_t(val + other.val); 
+        }
+        
+        __device__ __forceinline__ real_t operator-(const real_t& other) const { 
+            return real_t(val - other.val); 
+        }
+        
+        __device__ __forceinline__ real_t operator*(const real_t& other) const { 
+            return real_t(val * other.val); 
+        }
+        
+        __device__ __forceinline__ real_t operator/(const real_t& other) const { 
+            return real_t(val / other.val); 
+        }
+        
+        // Compound assignment operators
+        __device__ __forceinline__ real_t& operator+=(const real_t& other) { 
+            val += other.val; 
+            return *this; 
+        }
+        
+        __device__ __forceinline__ real_t& operator-=(const real_t& other) { 
+            val -= other.val; 
+            return *this; 
+        }
+        
+        __device__ __forceinline__ real_t& operator*=(const real_t& other) { 
+            val *= other.val; 
+            return *this; 
+        }
+        
+        __device__ __forceinline__ real_t& operator/=(const real_t& other) { 
+            val /= other.val; 
+            return *this; 
+        }
+        
+        // Comparison operators
+        __device__ __forceinline__ bool operator<(const real_t& other) const { 
+            return val < other.val; 
+        }
+        
+        __device__ __forceinline__ bool operator>(const real_t& other) const { 
+            return val > other.val; 
+        }
+        
+        __device__ __forceinline__ bool operator<=(const real_t& other) const { 
+            return val <= other.val; 
+        }
+        
+        __device__ __forceinline__ bool operator>=(const real_t& other) const { 
+            return val >= other.val; 
+        }
+        
+        // math
+        __device__ __forceinline__ static real_t sqrt(const real_t& x) { 
+            return real_t(sqrtf(x.val)); 
+        }
+        
+    };
+
+    // Non-member atomic operation
+    __device__ __forceinline__ void atomic_add(real_t* address, real_t val) {
+        atomicAdd(&(address->val), val.val);
+    }
+
+#endif
+
+// conversion
+__host__ __device__ __forceinline__ real_t to_real(float x) { return real_t(x); }
+__host__ __device__ __forceinline__ float from_real(real_t x) { return float(x); }
+
+#endif // PRECISION_TYPES_H

--- a/precision_types.h
+++ b/precision_types.h
@@ -2,6 +2,7 @@
 #define PRECISION_TYPES_H
 
 #include <cuda_fp16.h>
+#include <fstream>
 
 // comment for float32
 #define USE_FP16
@@ -156,8 +157,27 @@ struct real_t
         return real_t(1.0f / sqrtf(__half2float(x.val)));
 #endif
     }
-};
 
+    __host__ __device__ __forceinline__ std::ostream &operator<<(std::ostream &os, const real_t &x)
+    {
+#ifdef __CUDA_ARCH__
+        os << __half2float(x.val);
+#else
+        os << x.val;
+#endif
+        return os;
+    }
+
+    __host__ __device__ __forceinline__ std::istream &operator>>(std::istream &is, real_t &x)
+    {
+#ifdef __CUDA_ARCH__
+        is >> __half2float(x.val);
+#else
+        is >> x.val;
+#endif
+        return is;
+    }
+};
 
 // FP32
 #else

--- a/precision_types.h
+++ b/precision_types.h
@@ -17,9 +17,10 @@ struct real_t
     __half val;
 
     // Constructors
-    constexpr __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
-    constexpr __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
-    constexpr __host__ __device__ __forceinline__ real_t(const __half &h) : val(h) {}
+    __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
+    __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
+    __host__ __device__ __forceinline__ real_t(int i) : val(__float2half(float(i))) {}  // Add int constructor
+    __host__ __device__ __forceinline__ real_t(const __half& h) : val(h) {}
 
     // Conversion
     __host__ __device__ __forceinline__ operator float() const { return __half2float(val); }
@@ -157,27 +158,19 @@ struct real_t
         return real_t(1.0f / sqrtf(__half2float(x.val)));
 #endif
     }
-
-    __host__ __device__ __forceinline__ std::ostream &operator<<(std::ostream &os, const real_t &x)
-    {
-#ifdef __CUDA_ARCH__
-        os << __half2float(x.val);
-#else
-        os << x.val;
-#endif
-        return os;
-    }
-
-    __host__ __device__ __forceinline__ std::istream &operator>>(std::istream &is, real_t &x)
-    {
-#ifdef __CUDA_ARCH__
-        is >> __half2float(x.val);
-#else
-        is >> x.val;
-#endif
-        return is;
-    }
 };
+
+__host__ __device__ __forceinline__ std::ostream& operator<<(std::ostream& os, const real_t& x) {
+    os << __half2float(x.val);
+    return os;
+}
+
+__host__ __device__ __forceinline__ std::istream& operator>>(std::istream& is, real_t& x) {
+    float temp;
+    is >> temp;
+    x = real_t(temp);
+    return is;
+}
 
 // FP32
 #else

--- a/precision_types.h
+++ b/precision_types.h
@@ -19,7 +19,8 @@ struct real_t
     // Constructors
     __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
     __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
-    __host__ __device__ __forceinline__ real_t(int i) : val(__float2half(float(i))) {}  // Add int constructor
+    __host__ __device__ __forceinline__ real_t(double f) : val(__float2half(f)) {}
+    __host__ __device__ __forceinline__ real_t(int i) : val(__float2half(float(i))) {}
     __host__ __device__ __forceinline__ real_t(const __half& h) : val(h) {}
 
     // Conversion

--- a/precision_types.h
+++ b/precision_types.h
@@ -17,9 +17,9 @@ struct real_t
     __half val;
 
     // Constructors
-    __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
-    __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
-    __host__ __device__ __forceinline__ real_t(const __half &h) : val(h) {}
+    constexpr __host__ __device__ __forceinline__ real_t() : val(__float2half(0.0f)) {}
+    constexpr __host__ __device__ __forceinline__ real_t(float f) : val(__float2half(f)) {}
+    constexpr __host__ __device__ __forceinline__ real_t(const __half &h) : val(h) {}
 
     // Conversion
     __host__ __device__ __forceinline__ operator float() const { return __half2float(val); }

--- a/precision_types.h
+++ b/precision_types.h
@@ -82,6 +82,10 @@
         __device__ __forceinline__ static real_t sqrt(const real_t& x) { 
             return real_t(hsqrt(x.val)); 
         }
+
+        __device__ __forceinline__ static real_t rsqrt(const real_t& x) { 
+            return real_t(hrsqrt(x.val)); // 1/sqrt(x)
+        }
         
     };
 

--- a/ray.h
+++ b/ray.h
@@ -1,6 +1,7 @@
 #ifndef RAYH
 #define RAYH
 #include "vec3.h"
+#include "precision_types.h"
 
 class ray
 {
@@ -9,7 +10,7 @@ class ray
         __device__ ray(const vec3& a, const vec3& b) { A = a; B = b; }
         __device__ vec3 origin() const       { return A; }
         __device__ vec3 direction() const    { return B; }
-        __device__ vec3 point_at_parameter(float t) const { return A + t*B; }
+        __device__ vec3 point_at_parameter(real_t t) const { return A + t*B; }
 
         vec3 A;
         vec3 B;

--- a/sphere.h
+++ b/sphere.h
@@ -2,25 +2,26 @@
 #define SPHEREH
 
 #include "hitable.h"
+#include "precision_types.h"
 
 class sphere: public hitable  {
     public:
         __device__ sphere() {}
-        __device__ sphere(vec3 cen, float r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
-        __device__ virtual bool hit(const ray& r, float tmin, float tmax, hit_record& rec) const;
+        __device__ sphere(vec3 cen, real_t r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
+        __device__ virtual bool hit(const ray& r, real_t tmin, real_t tmax, hit_record& rec) const;
         vec3 center;
-        float radius;
+        real_t radius;
         material *mat_ptr;
 };
 
-__device__ bool sphere::hit(const ray& r, float t_min, float t_max, hit_record& rec) const {
+__device__ bool sphere::hit(const ray& r, real_t t_min, real_t t_max, hit_record& rec) const {
     vec3 oc = r.origin() - center;
-    float a = dot(r.direction(), r.direction());
-    float b = dot(oc, r.direction());
-    float c = dot(oc, oc) - radius*radius;
-    float discriminant = b*b - a*c;
+    real_t a = dot(r.direction(), r.direction());
+    real_t b = dot(oc, r.direction());
+    real_t c = dot(oc, oc) - radius*radius;
+    real_t discriminant = b*b - a*c;
     if (discriminant > 0) {
-        float temp = (-b - sqrt(discriminant))/a;
+        real_t temp = (-b - real_t::sqrt(discriminant))/a;
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);

--- a/sphere.h
+++ b/sphere.h
@@ -20,8 +20,12 @@ __device__ bool sphere::hit(const ray& r, real_t t_min, real_t t_max, hit_record
     real_t b = dot(oc, r.direction());
     real_t c = dot(oc, oc) - radius*radius;
     real_t discriminant = b*b - a*c;
-    if (discriminant > 0) {
+    if (discriminant > real_t(0)) {
+#ifdef USE_FP16
         real_t temp = (-b - real_t::sqrt(discriminant))/a;
+#else
+        real_t temp = (-b - sqrt(discriminant))/a;
+#endif
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);

--- a/vec3.h
+++ b/vec3.h
@@ -52,7 +52,11 @@ inline std::ostream& operator<<(std::ostream &os, const vec3 &t) {
 }
 
 __host__ __device__ inline void vec3::make_unit_vector() {
+#ifdef USE_FP16
     real_t k = real_t::rsqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
+#else
+    real_t k = 1.0 / sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
+#endif
     e[0] *= k; e[1] *= k; e[2] *= k;
 }
 

--- a/vec3.h
+++ b/vec3.h
@@ -4,38 +4,39 @@
 #include <math.h>
 #include <stdlib.h>
 #include <iostream>
+#include "precision_types.h"
 
 class vec3  {
 
 
 public:
     __host__ __device__ vec3() {}
-    __host__ __device__ vec3(float e0, float e1, float e2) { e[0] = e0; e[1] = e1; e[2] = e2; }
-    __host__ __device__ inline float x() const { return e[0]; }
-    __host__ __device__ inline float y() const { return e[1]; }
-    __host__ __device__ inline float z() const { return e[2]; }
-    __host__ __device__ inline float r() const { return e[0]; }
-    __host__ __device__ inline float g() const { return e[1]; }
-    __host__ __device__ inline float b() const { return e[2]; }
+    __host__ __device__ vec3(real_t e0, real_t e1, real_t e2) { e[0] = e0; e[1] = e1; e[2] = e2; }
+    __host__ __device__ inline real_t x() const { return e[0]; }
+    __host__ __device__ inline real_t y() const { return e[1]; }
+    __host__ __device__ inline real_t z() const { return e[2]; }
+    __host__ __device__ inline real_t r() const { return e[0]; }
+    __host__ __device__ inline real_t g() const { return e[1]; }
+    __host__ __device__ inline real_t b() const { return e[2]; }
 
     __host__ __device__ inline const vec3& operator+() const { return *this; }
     __host__ __device__ inline vec3 operator-() const { return vec3(-e[0], -e[1], -e[2]); }
-    __host__ __device__ inline float operator[](int i) const { return e[i]; }
-    __host__ __device__ inline float& operator[](int i) { return e[i]; };
+    __host__ __device__ inline real_t operator[](int i) const { return e[i]; }
+    __host__ __device__ inline real_t& operator[](int i) { return e[i]; };
 
     __host__ __device__ inline vec3& operator+=(const vec3 &v2);
     __host__ __device__ inline vec3& operator-=(const vec3 &v2);
     __host__ __device__ inline vec3& operator*=(const vec3 &v2);
     __host__ __device__ inline vec3& operator/=(const vec3 &v2);
-    __host__ __device__ inline vec3& operator*=(const float t);
-    __host__ __device__ inline vec3& operator/=(const float t);
+    __host__ __device__ inline vec3& operator*=(const real_t t);
+    __host__ __device__ inline vec3& operator/=(const real_t t);
 
-    __host__ __device__ inline float length() const { return sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]); }
-    __host__ __device__ inline float squared_length() const { return e[0]*e[0] + e[1]*e[1] + e[2]*e[2]; }
+    __host__ __device__ inline real_t length() const { return sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]); }
+    __host__ __device__ inline real_t squared_length() const { return e[0]*e[0] + e[1]*e[1] + e[2]*e[2]; }
     __host__ __device__ inline void make_unit_vector();
 
 
-    float e[3];
+    real_t e[3];
 };
 
 
@@ -51,7 +52,7 @@ inline std::ostream& operator<<(std::ostream &os, const vec3 &t) {
 }
 
 __host__ __device__ inline void vec3::make_unit_vector() {
-    float k = 1.0 / sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
+    real_t k = real_t::rsqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
     e[0] *= k; e[1] *= k; e[2] *= k;
 }
 
@@ -71,19 +72,19 @@ __host__ __device__ inline vec3 operator/(const vec3 &v1, const vec3 &v2) {
     return vec3(v1.e[0] / v2.e[0], v1.e[1] / v2.e[1], v1.e[2] / v2.e[2]);
 }
 
-__host__ __device__ inline vec3 operator*(float t, const vec3 &v) {
+__host__ __device__ inline vec3 operator*(real_t t, const vec3 &v) {
     return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
 }
 
-__host__ __device__ inline vec3 operator/(vec3 v, float t) {
+__host__ __device__ inline vec3 operator/(vec3 v, real_t t) {
     return vec3(v.e[0]/t, v.e[1]/t, v.e[2]/t);
 }
 
-__host__ __device__ inline vec3 operator*(const vec3 &v, float t) {
+__host__ __device__ inline vec3 operator*(const vec3 &v, real_t t) {
     return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
 }
 
-__host__ __device__ inline float dot(const vec3 &v1, const vec3 &v2) {
+__host__ __device__ inline real_t dot(const vec3 &v1, const vec3 &v2) {
     return v1.e[0] *v2.e[0] + v1.e[1] *v2.e[1]  + v1.e[2] *v2.e[2];
 }
 
@@ -122,15 +123,15 @@ __host__ __device__ inline vec3& vec3::operator-=(const vec3& v) {
     return *this;
 }
 
-__host__ __device__ inline vec3& vec3::operator*=(const float t) {
+__host__ __device__ inline vec3& vec3::operator*=(const real_t t) {
     e[0]  *= t;
     e[1]  *= t;
     e[2]  *= t;
     return *this;
 }
 
-__host__ __device__ inline vec3& vec3::operator/=(const float t) {
-    float k = 1.0/t;
+__host__ __device__ inline vec3& vec3::operator/=(const real_t t) {
+    real_t k = 1.0/t;
 
     e[0]  *= k;
     e[1]  *= k;


### PR DESCRIPTION
results in roughly 30% speedup time-wise and 1000% decrease in output quality. 

(Un)comment `#define USE_FP16` in `precision_types.h` to change between half and single precision.